### PR TITLE
fix: correct 2026 tax constants and add trygdeavgift transitional rule

### DIFF
--- a/lib/tax-rates.js
+++ b/lib/tax-rates.js
@@ -29,7 +29,7 @@ const TAX_RATES = {
      */
     trygdeavgift: {
       rate: 0.076,      // 7.6% for salary income
-      threshold: 69650  // No trygdeavgift below this annual income
+      threshold: 99650  // No trygdeavgift below this annual income (nedre grense 2026)
     },
 
     /**
@@ -54,7 +54,7 @@ const TAX_RATES = {
      * Personfradrag (Personal Allowance)
      * Fixed amount deducted from taxable income for all taxpayers
      */
-    personfradrag: 114210,  // 114,210 NOK
+    personfradrag: 114540,  // 114,540 NOK
 
     /**
      * Withholding Period Factor

--- a/lib/trekktabell.js
+++ b/lib/trekktabell.js
@@ -146,10 +146,13 @@ function calculateMonthlyWithholding(monthlyGross, tableNumber, taxYear = 2026) 
   // Trinnskatt: Progressive bracket tax on gross personal income
   const trinnskatt = calculateTrinnskatt(annualGross, rates.trinnskatt);
 
-  // Trygdeavgift: 7.6% national insurance on income above threshold
-  const trygdeavgift = annualGross > rates.trygdeavgift.threshold
+  // Trygdeavgift: 7.6% national insurance on gross income above threshold
+  // Transitional rule: cannot exceed 25% of income above threshold (prevents cliff at threshold)
+  const trygdeavgiftUncapped = annualGross > rates.trygdeavgift.threshold
     ? annualGross * rates.trygdeavgift.rate
     : 0;
+  const trygdeavgiftCap = Math.max(0, annualGross - rates.trygdeavgift.threshold) * 0.25;
+  const trygdeavgift = Math.min(trygdeavgiftUncapped, trygdeavgiftCap);
 
   // Inntektsskatt: 22% flat tax on alminnelig inntekt
   const inntektsskatt = alminneligInntekt * rates.alminneligInntekt.rate;
@@ -208,10 +211,13 @@ function calculateAnnualTax(annualGross, tableNumber, taxYear = 2026) {
   // Trinnskatt: Progressive bracket tax on gross personal income
   const trinnskatt = calculateTrinnskatt(annualGross, rates.trinnskatt);
 
-  // Trygdeavgift: 7.6% national insurance on income above threshold
-  const trygdeavgift = annualGross > rates.trygdeavgift.threshold
+  // Trygdeavgift: 7.6% national insurance on gross income above threshold
+  // Transitional rule: cannot exceed 25% of income above threshold (prevents cliff at threshold)
+  const trygdeavgiftUncapped = annualGross > rates.trygdeavgift.threshold
     ? annualGross * rates.trygdeavgift.rate
     : 0;
+  const trygdeavgiftCap = Math.max(0, annualGross - rates.trygdeavgift.threshold) * 0.25;
+  const trygdeavgift = Math.min(trygdeavgiftUncapped, trygdeavgiftCap);
 
   // Inntektsskatt: 22% flat tax on alminnelig inntekt
   const inntektsskatt = alminneligInntekt * rates.alminneligInntekt.rate;


### PR DESCRIPTION
- personfradrag: 114 210 → 114 540 NOK (official 2026 value)
- trygdeavgift.threshold: 69 650 → 99 650 NOK (official 2026 nedre grense)
- Add transitional rule for trygdeavgift: cap at 25% of income above threshold to prevent cliff effect near the lower threshold

The personfradrag and threshold errors caused incorrect absolute tax calculations for low earners (income 69 650–99 650 NOK would be wrongly charged trygdeavgift), and slightly overstated annual tax at all income levels. The marginal tax on overtime is unaffected for typical salaries well above the threshold.